### PR TITLE
Remove GetDeviceList API call

### DIFF
--- a/libpts/server/main.c
+++ b/libpts/server/main.c
@@ -223,12 +223,6 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "Failed to register port\n");
 		return 1;
 	}
-	char const *devices = GetDeviceList();
-
-	if (strstr(devices, port) == NULL) {
-		fprintf(stderr, "Failed to register device\n");
-		return 1;
-	}
 
 	SetPTSDevice(port);
 

--- a/libpts/server/main.c
+++ b/libpts/server/main.c
@@ -224,6 +224,13 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
+	// Previously, GetDeviceList() was called here to validate virtual COM port entry
+	// registered with Wine/Windows registry. However, later PTS versions (e.g., v8.9.0)
+	// no longer identify and report virtual COM ports, as these APIs primarily enumerate
+	// and target physical devices on native Windows. Since PTS still recognizes the port
+	// set with SetPTSDevice() and communicates with the chip including the older versions
+	// such as v8.0.3 without this API call, it has been removed.
+
 	SetPTSDevice(port);
 
 	success = VerifyDongleEx();


### PR DESCRIPTION
The pts-bot was calling GetDeviceList() to query and validate the virtual port created with wine/windows registry. However, based on PTS API documentation it seems to check only for physical devices and meant for native Windows env, causing pts-bot to terminate the execution in the latest PTS versions. PTS is still able to talk to the chip by calling SetPTSDevice() API with the virtual port number. Hence, removing this redundant API call, which is only meaningful for devices directly connected via USB or COM on native Windows setup.

Tested on PTS V8.0.3 and V8.9.0